### PR TITLE
moved database setup (and .env) down instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Vagrantfile
 - Edit `ansible/playbook.yml` to comment out any installations you don't need
 - Edit `ansible/config.yml` to configure versions and DB setup info
 - From within your Rails app folder, run `vagrant up`
+
+## Usage
+
+- From within your Rails app folder, run `vagrant ssh`. This will connect you to the Vagrant box.
+- From within the Vagrant box, run `cd /vagrant`
+- If this is a new Rails app that hasn't been created yet, run `rails new .`. This will create a new Rails app in that folder
 - Set up your app to use the database connection provided. Either:
   - Install the [`dotenv`](https://github.com/bkeepers/dotenv) gem and update your `database.yml` with the following entries:
 
@@ -31,12 +37,6 @@ Vagrantfile
           password: <%= ENV['DB_PASSWORD'] %>
 
   - Or, hard-code your `database.yml` file to use the same config as `ansible/config.yml` (not recommended)
-
-## Usage
-
-- From within your Rails app folder, run `vagrant ssh`. This will connect you to the Vagrant box.
-- From within the Vagrant box, run `cd /vagrant`
-- If this is a new Rails app that hasn't been created yet, run `rails new .`. This will create a new Rails app in that folder
 - Run any of your normal Rails setup commands, like `bundle install` and `bin/rake db:migrate`
 - Run `bin/rails server -b 0.0.0.0`
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Vagrantfile
 - Set up your app to use the database connection provided. Either:
   - Install the [`dotenv`](https://github.com/bkeepers/dotenv) gem and update your `database.yml` with the following entries:
 
+        ```
         development:
           host:     <%= ENV['DB_HOST'] %>
           database: <%= ENV['DB_NAME'] %>
@@ -35,6 +36,7 @@ Vagrantfile
           database: <%= ENV['DB_NAME'] %>_test
           username: <%= ENV['DB_USERNAME'] %>
           password: <%= ENV['DB_PASSWORD'] %>
+          ```
 
   - Or, hard-code your `database.yml` file to use the same config as `ansible/config.yml` (not recommended)
 - Run any of your normal Rails setup commands, like `bundle install` and `bin/rake db:migrate`

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Vagrantfile
 - If this is a new Rails app that hasn't been created yet, run `rails new .`. This will create a new Rails app in that folder
 - Set up your app to use the database connection provided. Either:
   - Install the [`dotenv`](https://github.com/bkeepers/dotenv) gem and update your `database.yml` with the following entries:
-        ```
+        ```yml
         development:
           host:     <%= ENV['DB_HOST'] %>
           database: <%= ENV['DB_NAME'] %>
@@ -35,7 +35,7 @@ Vagrantfile
           database: <%= ENV['DB_NAME'] %>_test
           username: <%= ENV['DB_USERNAME'] %>
           password: <%= ENV['DB_PASSWORD'] %>
-          ```
+        ```
 
   - Or, hard-code your `database.yml` file to use the same config as `ansible/config.yml` (not recommended)
 - Run any of your normal Rails setup commands, like `bundle install` and `bin/rake db:migrate`

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Vagrantfile
 - If this is a new Rails app that hasn't been created yet, run `rails new .`. This will create a new Rails app in that folder
 - Set up your app to use the database connection provided. Either:
   - Install the [`dotenv`](https://github.com/bkeepers/dotenv) gem and update your `database.yml` with the following entries:
-
         ```
         development:
           host:     <%= ENV['DB_HOST'] %>


### PR DESCRIPTION
Installation instructions for the .env gem ask the user to update their
Gemfile, which would not have existed if the user was creating a new
Rails app and following the instructions line by line.